### PR TITLE
Clarified CACHED_AUTH_PREPROCESSOR must return user

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,7 @@ database hit. Here's how we can implement it.
         # Handle exception for user with no profile and AnonymousUser
         except (Profile.DoesNotExist, AttributeError):
             pass
+        return user
 
 
     # In settings.py:


### PR DESCRIPTION
Updated README to indicate the CACHED_AUTH_PREPROCESSOR function has to return the user object.
